### PR TITLE
Origins Extra Keybinds, Bug Fixes

### DIFF
--- a/data/succsorigins/powers/american/advantages/stepheight.json
+++ b/data/succsorigins/powers/american/advantages/stepheight.json
@@ -3,6 +3,10 @@
     "description": "Navigate the terrain effortlessly by stepping up multiple blocks at a time, showcasing your adaptability.",
     "type": "origins:action_on_callback",
     "execute_chosen_when_orb": true,
+    "entity_action_lost": {
+        "type": "origins:execute_command",
+        "command": "scale reset @s"
+    },
     "entity_action_added": {
         "type": "origins:execute_command",
         "command": "scale set pehkui:step_height 5 @s"
@@ -10,5 +14,9 @@
     "entity_action_removed": {
         "type": "origins:execute_command",
         "command": "scale reset @s"
+    },
+    "entity_action_respawned": {
+        "type": "origins:execute_command",
+        "command": "scale set pehkui:step_height 5 @s"
     }
 }

--- a/data/succsorigins/powers/american/falldamage.json
+++ b/data/succsorigins/powers/american/falldamage.json
@@ -10,6 +10,14 @@
         "type": "origins:execute_command",
         "command": "scale reset @s"
     },
+    "entity_action_added": {
+        "type": "origins:execute_command",
+        "command": "scale set pehkui:falling 0.5 @s"
+    },
+    "entity_action_removed": {
+        "type": "origins:execute_command",
+        "command": "scale reset @s"
+    },
     "entity_action_respawned": {
         "type": "origins:execute_command",
         "command": "scale set pehkui:falling 0.5 @s"

--- a/data/succsorigins/powers/american/jump.json
+++ b/data/succsorigins/powers/american/jump.json
@@ -10,6 +10,14 @@
         "type": "origins:execute_command",
         "command": "scale reset @s"
     },
+    "entity_action_added": {
+        "type": "origins:execute_command",
+        "command": "scale set pehkui:jump_height 1.2 @s"
+    },
+    "entity_action_removed": {
+        "type": "origins:execute_command",
+        "command": "scale reset @s"
+    },
     "entity_action_respawned": {
         "type": "origins:execute_command",
         "command": "scale set pehkui:jump_height 1.2 @s"

--- a/data/succsorigins/powers/dragon/falldamage.json
+++ b/data/succsorigins/powers/dragon/falldamage.json
@@ -10,6 +10,14 @@
         "type": "origins:execute_command",
         "command": "scale reset @s"
     },
+    "entity_action_added": {
+        "type": "origins:execute_command",
+        "command": "scale set pehkui:falling 0.5 @s"
+    },
+    "entity_action_removed": {
+        "type": "origins:execute_command",
+        "command": "scale reset @s"
+    },
     "entity_action_respawned": {
         "type": "origins:execute_command",
         "command": "scale set pehkui:falling 0.5 @s"

--- a/data/succsorigins/powers/dragon/jump.json
+++ b/data/succsorigins/powers/dragon/jump.json
@@ -10,6 +10,10 @@
         "type": "origins:execute_command",
         "command": "scale reset @s"
     },
+    "entity_action_added": {
+        "type": "origins:execute_command",
+        "command": "scale set pehkui:jump_height 1.5 @s"
+    },
     "entity_action_removed": {
         "type": "origins:execute_command",
         "command": "scale reset @s"

--- a/data/succsorigins/powers/dragon/stepheight.json
+++ b/data/succsorigins/powers/dragon/stepheight.json
@@ -10,6 +10,14 @@
         "type": "origins:execute_command",
         "command": "scale reset @s"
     },
+    "entity_action_added": {
+        "type": "origins:execute_command",
+        "command": "scale set pehkui:step_height 2"
+    },
+    "entity_action_removed": {
+        "type": "origins:execute_command",
+        "command": "scale reset @s"
+    },
     "entity_action_respawned": {
         "type": "origins:execute_command",
         "command": "scale set pehkui:step_height 2"

--- a/data/succsorigins/powers/imploder/advantage/kinetic_boost.json
+++ b/data/succsorigins/powers/imploder/advantage/kinetic_boost.json
@@ -20,7 +20,7 @@
             },
             {
                 "type": "origins:area_of_effect",
-                "radius": 16,
+                "radius": 8,
                 "bientity_condition": {
                     "type": "origins:can_see"
                 },
@@ -53,6 +53,6 @@
         "bar_index": 12
     },
     "key": {
-        "key": "key.loadToolbarActivator"
+        "key": "key.origins.ternary_active"
     }
 }

--- a/data/succsorigins/powers/sunborn/combat_toggle.json
+++ b/data/succsorigins/powers/sunborn/combat_toggle.json
@@ -4,7 +4,7 @@
     "type": "origins:toggle",
     "active_by_default": false,
     "key": {
-        "key": "key.loadToolbarActivator"
+        "key": "key.origins.ternary_active"
     },
     "retain_state": true
 }

--- a/fabric.mod.json
+++ b/fabric.mod.json
@@ -9,7 +9,7 @@
     },
     "name": "Succ's Origins",
     "id": "succsorigins",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "description": "An addon for the origins mod, that adds custom origins made specifically for the power & precision: Back In Time modpack",
     "license": "Unknown",
     "icon": "pack.png",

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -3,7 +3,7 @@
         "name": "Succ's Origins",
         "id": "succsorigins",
         "pack_format": 15,
-        "version": "0.0.7",
+        "version": "0.0.8",
         "authors": [
             "IsuckAtEverything",
             "Suntix"


### PR DESCRIPTION
Origins Extra Keybinds are now used.

Fixed a bug with Origins American and Dragon where, every time they rejoined a world, they could no longer walk up blocks.